### PR TITLE
Fix malformed bashling theme file causing ST3 error

### DIFF
--- a/themes/bashling.tmTheme
+++ b/themes/bashling.tmTheme
@@ -7,7 +7,6 @@
 <plist version="1.0">
 <dict>
 	<key>name</key>
-Do
 	<string>bashling</string>
 	<key>settings</key>
 	<array>


### PR DESCRIPTION
I believe this fix will address the following error in ST3.
To repro before my fix:

1. open command palette
2. type `install theme`
3. type `bas`
4. See the following error

<img width="420" alt="capturfiles_6" src="https://cloud.githubusercontent.com/assets/1480063/10402087/09dde8d0-6e78-11e5-85f3-4e323473c538.png">


CC: @lingtalfi the author of the bashling theme.