### PR TITLE
Add Codecademy Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@ Themes creators
  - Rune Warhuus ([DinkDonk](https://github.com/DinkDonk))
  - [Nico Schuele](https://twitter.com/nicoschuele) ([Snakecasts](https://github.com/nicoschuele/snakecasts-theme))
  - [Charlotte Weaver](https://github.com/csweaver)
+ - [Geno Racklin Asher](https://github.com/Genora51)

--- a/themes.json
+++ b/themes.json
@@ -2087,12 +2087,12 @@
     "FileName": "Snakecasts.tmTheme",
     "Title": "Snakecasts"
   },
-	{
-		"Author": "Geno Racklin Asher",
-		"Description": "A theme very similar to Codecademy's, borrowing elements from 'Tomorrow Night - Bright' and Pacific Dark.",
-		"FileName": "Codecademy.tmTheme",
-		"Title": "Codecademy"
-	}
+  {
+    "Author": "Geno Racklin Asher",
+    "Description": "A theme very similar to Codecademy's, borrowing elements from 'Tomorrow Night - Bright' and Pacific Dark.",
+    "FileName": "Codecademy.tmTheme",
+    "Title": "Codecademy"
+  },
   {
 	"Title": "Butterfly",
 	"FileName": "Butterfly.tmTheme",

--- a/themes.json
+++ b/themes.json
@@ -2087,6 +2087,12 @@
     "FileName": "Snakecasts.tmTheme",
     "Title": "Snakecasts"
   },
+	{
+		"Author": "Geno Racklin Asher",
+		"Description": "A theme very similar to Codecademy's, borrowing elements from 'Tomorrow Night - Bright' and Pacific Dark.",
+		"FileName": "Codecademy.tmTheme",
+		"Title": "Codecademy"
+	}
   {
 	"Title": "Butterfly",
 	"FileName": "Butterfly.tmTheme",

--- a/themes/Codecademy.tmTheme
+++ b/themes/Codecademy.tmTheme
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>comment</key>
+	<string>A theme very similar to Codecademy's, borrowing elements from "Tomorrow Night - Bright" and Pacific Dark.</string>
+	<key>name</key>
+	<string>Codecademy</string>
+	<key>settings</key>
+	<array>
+		<dict>
+			<key>settings</key>
+			<dict>
+				<key>activeGuide</key>
+				<string>#7fb11b</string>
+				<key>guide</key>
+				<string>#4b6373</string>
+				<key>background</key>
+				<string>#354551</string>
+				<key>bracketContentsForeground</key>
+				<string>#f8f8f2a5</string>
+				<key>bracketContentsOptions</key>
+				<string>underline</string>
+				<key>bracketsForeground</key>
+				<string>#f8f8f2a5</string>
+				<key>bracketsOptions</key>
+				<string>underline</string>
+				<key>caret</key>
+				<string>#f8f8f0</string>
+				<key>findHighlight</key>
+				<string>#a4cccb</string>
+				<key>findHighlightForeground</key>
+				<string>#24353c</string>
+				<key>foreground</key>
+				<string>#f8f8f2</string>
+				<key>invisibles</key>
+				<string>#3b3a32</string>
+				<key>lineHighlight</key>
+				<string>#2a3034</string>
+				<key>selection</key>
+				<string>#2a3034</string>
+				<key>selectionBorder</key>
+				<string>#2a3034</string>
+				<key>gutterForeground</key>
+				<string>#5b798c</string>
+				<key>stackGuide</key>
+				<string>#635f2d</string>
+				<key>tagsOptions</key>
+				<string>stippled_underline</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment</string>
+			<key>scope</key>
+			<string>comment</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#969896</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Foreground</string>
+			<key>scope</key>
+			<string>keyword.operator.class, source.php.embedded.line</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#EEEEEE</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable, String Link, Regular Expression, Tag Name</string>
+			<key>scope</key>
+			<string>support.other.variable, string.other.link, string.regexp, entity.name.tag,
+			meta.tag, declaration.tag, punctuation.definition.tag</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#D54E53</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Number, Constant, Function Argument, Tag Attribute, Embedded</string>
+			<key>scope</key>
+			<string>constant.numeric, constant.language, support.constant, constant.character,  punctuation.section.embedded, keyword.other.unit, keyword.other.important, constant.other.color</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#E78C45</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Class, Support, Quoted Markup String</string>
+			<key>scope</key>
+			<string>entity.name.class, entity.name.type.class, support.type, support.class</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#E7C547</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>String, Symbols, Inherited Class, Markup Heading</string>
+			<key>scope</key>
+			<string>string, constant.other.symbol, entity.other.inherited-class, markup.heading, keyword.control.at-rule</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#B9CA4A</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Operator, Misc</string>
+			<key>scope</key>
+			<string>keyword.operator, punctuation.separator.key-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#70C0B1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Function, Special Method, Block Level</string>
+			<key>scope</key>
+			<string>entity.name.function, support.function, keyword.other.special-method, meta.block-level</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#7AA6DA</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword, Storage</string>
+			<key>scope</key>
+			<string>keyword, storage, storage.type, entity.name.tag.css, keyword.other.unit, entity.other.attribute-name.id.css</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#C397D8</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Invalid</string>
+			<key>scope</key>
+			<string>invalid</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#DF5F5F</string>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#CED2CF</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Separator</string>
+			<key>scope</key>
+			<string>meta.separator</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#82A3BF</string>
+				<key>foreground</key>
+				<string>#CED2CF</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Deprecated</string>
+			<key>scope</key>
+			<string>invalid.deprecated</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#B798BF</string>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#CED2CF</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML Attribute, CSS Class/ID</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#D54E53</string>
+			</dict>
+		</dict>
+		
+		<dict>
+			<key>name</key>
+			<string>CSS Tag Name</string>
+			<key>scope</key>
+			<string>entity.name.tag.css, punctuation.separator.key-value.css, support.type.vendor-prefix, support.type.property-vendor</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f8f8f2</string>
+			</dict>
+		</dict>
+	</array>
+	<key>uuid</key>
+	<string>33D8C715-AD3A-455B-8DF2-56F708909FFE</string>
+</dict>
+</plist>


### PR DESCRIPTION
This merge adds a new theme I have created, in the style of Codecademy's editor. The theme takes elements from [Tomorrow Night - Bright](https://github.com/chriskempson/tomorrow-theme) and [Pacific Dark](https://github.com/hrsetyono/theme_pacific). The theme is fully compatible (and best used with) [Theme - Pacific](https://github.com/hrsetyono/theme_pacific).
![preview](https://cloud.githubusercontent.com/assets/19515086/25013974/c8120c3e-206d-11e7-8bf7-234cf585ed64.PNG)
![pacific](https://cloud.githubusercontent.com/assets/19515086/25013977/c9bd4062-206d-11e7-9b81-820bd1b388bb.png)
