### PR TITLE
Fix broken themes; enhance theme parsing test

### DIFF
--- a/tests/themes-parsing.spec.js
+++ b/tests/themes-parsing.spec.js
@@ -253,7 +253,10 @@ describe('The themes can be parsed correctly', function() {
 		this.timeout(15000);
 		themes.forEach(function(theme, i) {
 			try {
-				libxml.parseXmlString(theme.body);
+				var res = libxml.parseXml(theme.body);
+				if (res.errors.length > 0) {
+					throw new Error(JSON.stringify(res.errors));
+				}
 			} catch (e) {
 				e.message = 'Can\'t parse ' + theme.name + '. ' + e.message;
 				throw e;

--- a/tests/themes-parsing.spec.js
+++ b/tests/themes-parsing.spec.js
@@ -242,6 +242,7 @@ function extractStyles(theme) {
 }
 
 describe('The themes can be parsed correctly', function() {
+	this.timeout(15000);
 	var themes = themesFiles.map(function(theme, i) {
 		return {
 			'body': fs.readFileSync(THEMES_DIR + theme.name, 'utf8'),
@@ -250,7 +251,6 @@ describe('The themes can be parsed correctly', function() {
 	});
 
 	it('Themes are valid XML', function(done) {
-		this.timeout(15000);
 		themes.forEach(function(theme, i) {
 			try {
 				var res = libxml.parseXml(theme.body);
@@ -266,11 +266,20 @@ describe('The themes can be parsed correctly', function() {
 	});
 
 	it('I could get the colors for all the themes', function(done) {
-		this.timeout(15000);
 		themes.forEach(function(theme, i) {
 			currentTheme = theme.name;
 			var themeParsed = plist.parse(theme.body);
 			extractStyles(themeParsed);
+			if (i === themes.length - 1) {done();}
+		});
+	});
+
+	it('Themes have a valid name', function(done) {
+		themes.forEach(function(theme, i) {
+			var themeParsed = plist.parse(theme.body);
+			if (themeParsed.name === undefined || themeParsed.name.trim().length === 0) {
+				throw new Error(theme.name + ' is missing a key-string pair for "name".');
+			}
 			if (i === themes.length - 1) {done();}
 		});
 	});

--- a/tests/themes-parsing.spec.js
+++ b/tests/themes-parsing.spec.js
@@ -242,7 +242,6 @@ function extractStyles(theme) {
 }
 
 describe('The themes can be parsed correctly', function() {
-	this.timeout(15000);
 	var themes = themesFiles.map(function(theme, i) {
 		return {
 			'body': fs.readFileSync(THEMES_DIR + theme.name, 'utf8'),
@@ -251,11 +250,12 @@ describe('The themes can be parsed correctly', function() {
 	});
 
 	it('Themes are valid XML', function(done) {
+		this.timeout(15000);
 		themes.forEach(function(theme, i) {
 			try {
 				var res = libxml.parseXml(theme.body);
 				if (res.errors.length > 0) {
-					throw new Error(JSON.stringify(res.errors));
+					throw new Error(theme.name + ' doesn\'t appear to be valid XML, see the following errors: ' + JSON.stringify(res.errors));
 				}
 			} catch (e) {
 				e.message = 'Can\'t parse ' + theme.name + '. ' + e.message;
@@ -266,6 +266,7 @@ describe('The themes can be parsed correctly', function() {
 	});
 
 	it('I could get the colors for all the themes', function(done) {
+		this.timeout(15000);
 		themes.forEach(function(theme, i) {
 			currentTheme = theme.name;
 			var themeParsed = plist.parse(theme.body);
@@ -275,6 +276,7 @@ describe('The themes can be parsed correctly', function() {
 	});
 
 	it('Themes have a valid name', function(done) {
+		this.timeout(15000);
 		themes.forEach(function(theme, i) {
 			var themeParsed = plist.parse(theme.body);
 			if (themeParsed.name === undefined || themeParsed.name.trim().length === 0) {

--- a/themes/NeonGlow.tmTheme
+++ b/themes/NeonGlow.tmTheme
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
+		<key>name</key>
+		<string>NeonGlow</string>
 		<key>settings</key>
 		<array>
 			<!-- General -->

--- a/themes/RamdaJS.tmTheme
+++ b/themes/RamdaJS.tmTheme
@@ -8,7 +8,7 @@
 <!-- code: https://github.com/aziz/tmTheme-Editor -->
 <plist version="1.0">
 <dict>
-	<key>Ramda</key>
+	<key>name</key>
 	<string>Ramda</string>
 	<key>settings</key>
 	<array>

--- a/themes/blockninja.tmTheme
+++ b/themes/blockninja.tmTheme
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.1">
 <dict>


### PR DESCRIPTION
Closes #342

Specific errors I fixed by theme:

* NeonGlow (added by @farzher) - was missing a key-string pair of `name` at the top level `<dict>`
* blockninja (added by @AlexDunmow) - wrong XML schema version
* RamdaJS (added by @kenjikatahira )- had `Ramda` for both the `<key>` and `<string>` tags, where the `<key>` should've been name.

The tests I tweaked will catch errors like these.