### PR TITLE
Make comments not black

### DIFF
--- a/themes/Better_JS.tmTheme
+++ b/themes/Better_JS.tmTheme
@@ -47,7 +47,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#000000</string>
+				<string>#6d6d6d</string>
 				<key>fontStyle</key>
 				<string> italic </string>
 			</dict>


### PR DESCRIPTION
It's very hard to read black comments on top of darker backgrounds, and gray is a very standard default color.