### PR TITLE
Update Chelevra themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Themes creators
 -   Joe Bergantine
 -   Johan Tique
 -   John-Paul Bader
--   Jonas Hermsmeier
+-   Jonas Hermsmeier ([jhermsmeier](https://github.com/jhermsmeier))
 -   Jonathan Santos
 -   Josema Enzo
 -   Josh Burgess

--- a/themes/Chelevra-Ayu.tmTheme
+++ b/themes/Chelevra-Ayu.tmTheme
@@ -19,6 +19,8 @@
         <string>underline</string>
         <key>caret</key>
         <string>#91E1FB</string>
+        <key>block_caret</key>
+        <string>#91E1FB</string>
         <key>findHighlight</key>
         <string>#FFE792</string>
         <key>findHighlightForeground</key>
@@ -166,7 +168,7 @@
       <key>name</key>
       <string>Storage</string>
       <key>scope</key>
-      <string>storage</string>
+      <string>storage,source.c++ support.type, storage.type</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>
@@ -497,7 +499,7 @@
       <key>name</key>
       <string>markdown.heading</string>
       <key>scope</key>
-      <string>markup.heading.markdown entity.name.section.markdown</string>
+      <string>markup.heading entity.name.section.markdown</string>
       <key>settings</key>
       <dict>
         <key>fontStyle</key>

--- a/themes/Chelevra-Material.tmTheme
+++ b/themes/Chelevra-Material.tmTheme
@@ -19,6 +19,8 @@
 				<string>underline</string>
 				<key>caret</key>
 				<string>#91E1FB</string>
+				<key>block_caret</key>
+				<string>#91E1FB</string>
 				<key>findHighlight</key>
 				<string>#FFE792</string>
 				<key>findHighlightForeground</key>
@@ -166,7 +168,7 @@
 			<key>name</key>
 			<string>Storage</string>
 			<key>scope</key>
-			<string>storage</string>
+			<string>storage,source.c++ support.type, storage.type</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
@@ -497,7 +499,7 @@
 			<key>name</key>
 			<string>markdown.heading</string>
 			<key>scope</key>
-			<string>markup.heading.markdown entity.name.section.markdown</string>
+			<string>markup.heading entity.name.section.markdown</string>
 			<key>settings</key>
 			<dict>
 				<key>fontStyle</key>


### PR DESCRIPTION
This updates the [Chelevra themes](https://github.com/jhermsmeier/chelevra.tmtheme) with some minor fixes for the newly added `block_caret` and markdown rendering.