### PR TITLE
Unofficial GitLab Color Scheme with Light and Dark variants

### DIFF
--- a/themes.json
+++ b/themes.json
@@ -2260,5 +2260,17 @@
     "FileName": "Sahara.tmTheme",
     "Author": "Christopher Jaoude",
     "Description": "Unique sand theme: high endurance, low eye strain. (v0.5)"
+  },
+  {
+    "Author": "Sri",
+    "Description": "Unofficial GitLab inspired light color scheme",
+    "FileName": "gitlab-light.sublime-color-scheme",
+    "Title": "GitLab Light (Unofficial)"
+  },
+  {
+    "Author": "Sri",
+    "Description": "Unofficial GitLab inspired dark color scheme",
+    "FileName": "gitlab-dark.sublime-color-scheme",
+    "Title": "GitLab Dark (Unofficial)"
   }
 ]

--- a/themes/gitlab-dark.sublime-color-scheme
+++ b/themes/gitlab-dark.sublime-color-scheme
@@ -1,0 +1,68 @@
+{
+    "name": "GitLab Dark Color Scheme",
+    "variables":
+    {
+        "orange_light": "#fca121",
+        "orange": "#fc6d26",
+        "red": "#db3b21",
+        "purple_light": "#6e49cb",
+        "purple": "#380d75",
+        "gray_dark": "#2e2e2e",
+        "gray_light": "#9e9e9e",
+        "white": "#fff",
+        "white_faded": "#f9f9f9",
+    },
+    "globals":
+    {
+        "background": "var(gray_dark)",
+        "foreground": "var(white_faded)",
+        "caret": "var(white_faded)",
+        "selection_foreground": "var(white)",
+    },
+    "rules":
+    [
+        {
+            "name": "Comment",
+            "scope": "comment",
+            "foreground": "var(gray_light)",
+        },
+        {
+            "name": "Invalid",
+            "scope": "invalid",
+            "foreground": "var(gray_light)",
+        },
+        {
+            "name": "String",
+            "scope": "string",
+            "foreground": "var(orange_light)",
+        },
+        {
+            "name": "Number",
+            "scope": "constant.numeric",
+            "foreground": "var(orange_light)",
+        },
+        {
+            "name": "Variable",
+            "scope": "variable",
+            "foreground": "var(orange)",
+        },
+        {
+            "name": "Entity",
+            "scope": "entity",
+            "foreground": "var(orange)",
+            "font_style": "italic",
+        },
+        {
+            "name": "Keyword",
+            "scope": "keyword",
+            "foreground": "var(orange)",
+            "font_style": "italic",
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "foreground": "var(orange)",
+            "font_style": "italic",
+        },
+    ]
+}

--- a/themes/gitlab-light.sublime-color-scheme
+++ b/themes/gitlab-light.sublime-color-scheme
@@ -1,0 +1,65 @@
+{
+    "name": "GitLab Light Color Scheme",
+    "variables":
+    {
+        "orange_light": "#fca121",
+        "orange": "#fc6d26",
+        "red": "#db3b21",
+        "purple_light": "#6e49cb",
+        "purple": "#380d75",
+        "gray_dark": "#2e2e2e",
+        "gray_light": "#9e9e9e",
+        "white": "#fff",
+    },
+    "globals":
+    {
+        "background": "var(white)",
+        "foreground": "var(purple)",
+        "caret": "var(orange)",
+        "selection_foreground": "var(white)"
+    },
+    "rules":
+    [
+        {
+            "name": "Comment",
+            "scope": "comment",
+            "foreground": "var(gray_light)",
+        },
+        {
+            "name": "Invalid",
+            "scope": "invalid",
+            "foreground": "var(gray_light)",
+        },
+        {
+            "name": "String",
+            "scope": "string",
+            "foreground": "var(red)",
+        },
+        {
+            "name": "Number",
+            "scope": "constant.numeric",
+            "foreground": "var(red)",
+        },
+        {
+            "name": "Variable",
+            "scope": "variable",
+            "foreground": "var(purple_light)",
+        },
+        {
+            "name": "Entity",
+            "scope": "entity",
+            "foreground": "var(gray_dark)",
+        },
+        {
+            "name": "Keyword",
+            "scope": "keyword",
+            "foreground": "var(gray_dark)",
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "foreground": "var(gray_dark)",
+            "font_style": "italic",
+        },
+    ]
+}


### PR DESCRIPTION
Added an official GitLab color scheme with light and dark variants.

Repository and examples here: https://gitlab.com/sri19/gitlab-color-scheme