### PR TITLE
Welded.tmTheme: Removed a="asd" attribute from Tag attribute key tag

### DIFF
--- a/themes/Welded.tmTheme
+++ b/themes/Welded.tmTheme
@@ -237,7 +237,7 @@
 			</dict>
 		</dict>
 		<dict>
-			<key a="asd">name</key>
+			<key>name</key>
 			<string>Tag attribute</string>
 			<key>scope</key>
 			<string>entity.other.attribute-name</string>


### PR DESCRIPTION
I've found a minor issue with Welded.tmTheme.

Key tag for `Tag attribute` contains extra `a="asd"` attribute which is not valid according to plist dtd (key tags shouldn't have any attributes). Although this seems Sublime ignores this attribute and theme works just fine, this extra attribute causes problems when validating XML or using `fast-plist` to parse the file.

I've also checked for the possibility of adding `dtd` validation for the tests but seems `libxmljs` doesn't support DTD validation.

Btw, this is only theme failing validation. All others are just fine!

I've also opened similar PR in original theme repo: maebert/welded-colour-scheme#3