### PR TITLE
Update activeGuide for Monokai-Contrast

### DIFF
--- a/themes/Monokai-Contrast.tmTheme
+++ b/themes/Monokai-Contrast.tmTheme
@@ -28,7 +28,7 @@
 				<key>selectionBorder</key>
 				<string>#222218</string>
 				<key>activeGuide</key>
-				<string>#9D550FB0</string>
+				<string>#666666</string>
 
 				<key>bracketsForeground</key>
 				<string>#F8F8F2A5</string>


### PR DESCRIPTION
This improves usability when using `"indent_guide_options": ["draw_active"]`